### PR TITLE
fix mongo auth

### DIFF
--- a/deployment/conf/.templates/deployment.cfg.templ
+++ b/deployment/conf/.templates/deployment.cfg.templ
@@ -8,7 +8,10 @@ mongo-password = {{ default .Env.mongo_password "" }}
 
 start-local-mongo = {{ default .Env.start_local_mongo "0" }}
 
+auth-service-url = {{ default .Env.auth_service_url "http://localhost" }}
 shock-url = {{ default .Env.shock_url "http://localhost" }}
+workspace-url = {{ default .Env.workspace_url "http://localhost" }}
+handle-service-url = {{ default .Env.handle_url "http://localhost" }}
 
 # KBase auth roles for the account approved to assign/modify shock node ACLs (run add_read_acl).
 admin-roles = {{ default .Env.admin_roles "HANDLE_ADMIN, KBASE_ADMIN" }}

--- a/deployment/conf/.templates/deployment.cfg.templ
+++ b/deployment/conf/.templates/deployment.cfg.templ
@@ -2,7 +2,7 @@
 mongo-host  = {{ default .Env.mongo_host "localhost" }}
 mongo-port  = {{ default .Env.mongo_port "27017" }}
 mongo-database = {{ default .Env.mongo_database "handle_db" }}
-mongo-authmechanism = {{ default .Env.mongo_authMechanism "DEFAULT" }}
+mongo-authmechanism = {{ default .Env.mongo_authmechanism "DEFAULT" }}
 mongo-user = {{ default .Env.mongo_user "" }}
 mongo-password = {{ default .Env.mongo_password "" }}
 

--- a/lib/AbstractHandle/AbstractHandleImpl.py
+++ b/lib/AbstractHandle/AbstractHandleImpl.py
@@ -39,7 +39,7 @@ provides a programmatic access to a remote file store
         self.config = config
         self.config['mongo-collection'] = self.MONGO_COLLECTION
         self.config['mongo-hid-counter-collection'] = self.MONGO_HID_COUNTER_COLLECTION
-        self.config['mongo-authmechanism'] = self.MONGO_AUTHMECHANISM
+        self.config.setdefault('mongo-authmechanism', self.MONGO_AUTHMECHANISM)
 
         logging.basicConfig(format='%(created)s %(levelname)s: %(message)s',
                             level=logging.INFO)

--- a/lib/AbstractHandle/Utils/MongoUtil.py
+++ b/lib/AbstractHandle/Utils/MongoUtil.py
@@ -33,9 +33,10 @@ class MongoUtil:
         """
 
         if mongo_user:
-            logging.info('mongo-user found in config file, configuring client for authentication')
+            logging.info('mongo-user found in config file, configuring client for authentication using mech ' + str(mongo_authmechanism) )
             my_client = MongoClient(mongo_host, mongo_port,
                                     username=mongo_user, password=mongo_password,
+                                    authSource=mongo_database,
                                     authMechanism=mongo_authmechanism)
         else:
             logging.info('no mongo-user found in config file, connecting without auth')


### PR DESCRIPTION
The template file casts to lower case.  Also needs more URLs defined (auth, ws, handle).

MongoClient needs to be told which database to authenticate against.