### PR TITLE
Update mysql to mongo importer

### DIFF
--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -169,7 +169,7 @@ def main(argv):
                 insert_result = my_collection.insert_many(doc_insert_list,ordered=False)
             except BulkWriteError as bwe:
                 print(bwe.details)
-            print ('inserted {} records'.format(len(insert_result.inserted_ids)
+            print ('inserted {} records'.format(len(insert_result.inserted_ids)))
             doc_insert_list = []
 #        if insert_one(my_collection, doc):
 #            insert_records += 1

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -150,17 +150,17 @@ def main(argv):
         hid = doc['hid']
         doc['_id'] = hid
 
-        try:
-            counter_str = hid.split('KBH_')[-1]
-        except Exception:
-            counter = hid
-        try:
-            counter = int(counter_str)
-        except Exception:
-            counter = 0
-
-        if counter > max_counter:
-            max_counter = counter
+#        try:
+#            counter_str = hid.split('KBH_')[-1]
+#        except Exception:
+#            counter = hid
+#        try:
+#            counter = int(counter_str)
+#        except Exception:
+#            counter = 0
+#
+#        if counter > max_counter:
+#            max_counter = counter
 
         doc_insert_list.append(doc)
         
@@ -185,14 +185,15 @@ def main(argv):
     print ('inserted {} records'.format(len(insert_result.inserted_ids)))
     doc_insert_list = []
 
-    maxId = my_collection.find_one( sort = [("_id", -1)] )["_id"]
-    print ( maxId )
+# get the max_id from the handle collection itself instead of from the mysql ids
+    max_id = my_collection.find_one( sort = [("_id", -1)] )["_id"]
+    print ( max_id )
     
     counter_collection.delete_many({})
-    counter_collection.insert_one({'_id': 'hid_counter', 'hid_counter': max_counter + 1})
+    counter_collection.insert_one({'_id': 'hid_counter', 'hid_counter': max_id + 1})
 
 #    print('totally inserted {} records'.format(insert_records))
-    print('largest counter'.format(max_counter))
+    print('max id: {} '.format(max_id))
 
 
 if __name__ == "__main__":

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -161,7 +161,7 @@ def main(argv):
             insert_records += 1
 
         if insert_records%5000 == 0:
-            print('inserted {} records'.format(insert_records))
+            print('counter {}, inserted {} records'.format(counter, insert_records))
 
     counter_collection.delete_many({})
     counter_collection.insert_one({'_id': 'hid_counter', 'hid_counter': max_counter + 1})

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -185,7 +185,9 @@ def main(argv):
     print ('inserted {} records'.format(len(insert_result.inserted_ids)))
     doc_insert_list = []
 
-
+    maxId = my_collection.find_one( sort = [("_id", 1)]["_id"] )
+    print ( maxId )
+    
     counter_collection.delete_many({})
     counter_collection.insert_one({'_id': 'hid_counter', 'hid_counter': max_counter + 1})
 

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -162,7 +162,10 @@ def main(argv):
         doc_insert_list.append(doc)
         
         if len(doc_insert_list) % 1000 == 0:
-            insert_result = my_collection.insert_many(doc_insert_list,ordered=False)
+            try:
+                insert_result = my_collection.insert_many(doc_insert_list,ordered=False)
+            except BulkWriteError as bwe:
+                print(bwe.details)
             print (insert_result)
             doc_insert_list = []
 #        if insert_one(my_collection, doc):

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -161,7 +161,7 @@ def main(argv):
             insert_records += 1
 
         if insert_records%5000 == 0:
-            print('counter {}, inserted {} records'.format(counter, insert_records))
+            print('hid {}, inserted {} records'.format(hid, insert_records))
 
     counter_collection.delete_many({})
     counter_collection.insert_one({'_id': 'hid_counter', 'hid_counter': max_counter + 1})

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -85,6 +85,7 @@ def main(argv):
     try:
         opts, args = getopt.getopt(argv, "h", [a + '=' for a in input_args])
     except getopt.GetoptError:
+        print('unrecognized option provided')
         print(usage_string)
         sys.exit(2)
     for opt, arg in opts:

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -169,7 +169,7 @@ def main(argv):
                 insert_result = my_collection.insert_many(doc_insert_list,ordered=False)
             except BulkWriteError as bwe:
                 print(bwe.details)
-            print (insert_result.bulk_api_result)
+#            print (insert_result.bulk_api_result)
             doc_insert_list = []
 #        if insert_one(my_collection, doc):
 #            insert_records += 1

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -117,7 +117,7 @@ def main(argv):
     insert_records = 0
     max_counter = 0
     for x in mycursor:
-        print x
+        print (x)
         doc = dict(zip(columns, x))
         hid = doc['hid']
         doc['_id'] = hid

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -2,8 +2,11 @@
 
 
 import mysql.connector
+
 from pymongo import MongoClient
 from pymongo.errors import ServerSelectionTimeoutError
+from pymongo.errors import BulkWriteError
+
 import traceback
 import sys
 import getopt

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -79,7 +79,10 @@ def main(argv):
     sql_username = ''
     sql_password = ''
     mongo_host = ''
-    
+    mongo_username = None
+    mongo_password = None
+    mongo_authmechanism = 'DEFAULT'
+
     usage_string = 'mysql_to_mongo.py --sql_server <sql_server> --sql_username <sql_username> --sql_password <sql_password> --mongo_host <mongo_host> [ --mongo_username <mongo_username> --mongo_password <mongo_password> [ --mongo_authmechanism <mongo_authmechanism> ] ]'
 
     try:
@@ -116,8 +119,8 @@ def main(argv):
     mongo_database = 'handle_db'
     mongo_collection = 'handle'
     mongo_counter_collection = 'handle_id_counter'
-    my_collection = connect_mongo(mongo_host, mongo_port, mongo_database, mongo_collection)
-    counter_collection = connect_mongo(mongo_host, mongo_port, mongo_database, mongo_counter_collection)
+    my_collection = connect_mongo(mongo_host, mongo_port, mongo_database, mongo_collection, mongo_username, mongo_password, mongo_authmechanism)
+    counter_collection = connect_mongo(mongo_host, mongo_port, mongo_database, mongo_counter_collection, mongo_username, mongo_password, mongo_authmechanism)
 
     mycursor.execute("SELECT COUNT(*) FROM Handle")
     myresult = mycursor.fetchall()

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -185,7 +185,7 @@ def main(argv):
     print ('inserted {} records'.format(len(insert_result.inserted_ids)))
     doc_insert_list = []
 
-    maxId = my_collection.find_one( sort = [("_id", 1)]["_id"] )
+    maxId = my_collection.find_one( sort = [("_id", 1)] )["_id"]
     print ( maxId )
     
     counter_collection.delete_many({})

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -121,7 +121,11 @@ def main(argv):
         doc = dict(zip(columns, x))
         hid = doc['hid']
         doc['_id'] = hid
-        counter_str = hid.split('KBH_')[-1]
+
+        try:
+            counter_str = hid.split('KBH_')[-1]
+        except Exception:
+            counter = hid
         try:
             counter = int(counter_str)
         except Exception:

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -117,6 +117,7 @@ def main(argv):
     insert_records = 0
     max_counter = 0
     for x in mycursor:
+        print x
         doc = dict(zip(columns, x))
         hid = doc['hid']
         doc['_id'] = hid

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -109,14 +109,14 @@ def main(argv):
     print('total MySQL record count: {}'.format(total_records))
 
     mycursor.execute("SELECT * FROM Handle")
-    myresult = mycursor.fetchall()
+#    myresult = mycursor.fetchall()
 
     columns = ['hid', 'id', 'file_name', 'type', 'url', 'remote_md5', 'remote_sha1',
                'created_by', 'creation_date']
 
     insert_records = 0
     max_counter = 0
-    for x in myresult:
+    for x in mycursor:
         doc = dict(zip(columns, x))
         hid = doc['hid']
         doc['_id'] = hid

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -185,7 +185,7 @@ def main(argv):
     print ('inserted {} records'.format(len(insert_result.inserted_ids)))
     doc_insert_list = []
 
-    maxId = my_collection.find_one( sort = [("_id", 1)] )["_id"]
+    maxId = my_collection.find_one( sort = [("_id", -1)] )["_id"]
     print ( maxId )
     
     counter_collection.delete_many({})

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -21,7 +21,19 @@ def connect_mysql(sql_server, sql_username, sql_password, sql_database):
     return my_sqldb
 
 
-def connect_mongo(mongo_host, mongo_port, mongo_database, mongo_collection):
+def connect_mongo(mongo_host, mongo_port, mongo_database, mongo_collection,
+                  mongo_user=None, mongo_pass=None, mongo_authmechanism='DEFAULT'):
+
+    if mongo_user:
+        print('mongo_user supplied, configuring client for authentication using mech ' + str(mongo_authmechanism) )
+        my_client = MongoClient(mongo_host, mongo_port,
+                                username=mongo_user, password=mongo_password,
+                                authSource=mongo_database,
+                                authMechanism=mongo_authmechanism)
+    else:
+        print('no mongo_user supplied, connecting without auth')
+        my_client = MongoClient(mongo_host, mongo_port)
+    
     my_client = MongoClient(mongo_host, mongo_port)
 
     try:
@@ -61,20 +73,23 @@ def insert_one(my_collection, doc):
 
 def main(argv):
 
-    input_args = ['sql_server', 'sql_username', 'sql_password', 'mongo_host', 'mongo_username', 'mongo_password']
+    input_args = ['sql_server', 'sql_username', 'sql_password', 'mongo_host',
+                  'mongo_username', 'mongo_password', 'mongo_authmechanism']
     sql_server = ''
     sql_username = ''
     sql_password = ''
     mongo_host = ''
+    
+    usage_string = 'mysql_to_mongo.py --sql_server <sql_server> --sql_username <sql_username> --sql_password <sql_password> --mongo_host <mongo_host> [ --mongo_username <mongo_username> --mongo_password <mongo_password> ]'
 
     try:
         opts, args = getopt.getopt(argv, "h", [a + '=' for a in input_args])
     except getopt.GetoptError:
-        print('mysql_to_mongo.py --sql_server <sql_server> --sql_username <sql_username> --sql_password <sql_password> --mongo_host <mongo_host> [ --mongo_username <mongo_username> --mongo_password <mongo_password> ]')
+        print(usage_string)
         sys.exit(2)
     for opt, arg in opts:
         if opt == '-h':
-            print('mysql_to_mongo.py --sql_server <sql_server> --sql_username <sql_username> --sql_password <sql_password> --mongo_host <mongo_host> [ --mongo_username <mongo_username> --mongo_password <mongo_password> ]')
+            print(usage_string)
             sys.exit()
         elif opt == '--sql_server':
             sql_server = arg
@@ -87,7 +102,7 @@ def main(argv):
 
     if not all([sql_server, sql_username, sql_password, mongo_host]):
         print('missing one of requried args')
-        print('mysql_to_mongo.py --sql_server <sql_server> --sql_username <sql_username> --sql_password <sql_password> --mongo_host <mongo_host> [ --mongo_username <mongo_username> --mongo_password <mongo_password> ]')
+        print(usage_string)
         sys.exit()
 
     sql_port = 3306

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -61,7 +61,7 @@ def insert_one(my_collection, doc):
 
 def main(argv):
 
-    input_args = ['sql_server', 'sql_username', 'sql_password', 'mongo_host']
+    input_args = ['sql_server', 'sql_username', 'sql_password', 'mongo_host', 'mongo_username', 'mongo_password']
     sql_server = ''
     sql_username = ''
     sql_password = ''
@@ -70,11 +70,11 @@ def main(argv):
     try:
         opts, args = getopt.getopt(argv, "h", [a + '=' for a in input_args])
     except getopt.GetoptError:
-        print('mysql_to_mongo.py --sql_server <sql_server> --sql_username <sql_username> --sql_password <sql_password> --mongo_host <mongo_host>')
+        print('mysql_to_mongo.py --sql_server <sql_server> --sql_username <sql_username> --sql_password <sql_password> --mongo_host <mongo_host> [ --mongo_username <mongo_username> --mongo_password <mongo_password> ]')
         sys.exit(2)
     for opt, arg in opts:
         if opt == '-h':
-            print('mysql_to_mongo.py --sql_server <sql_server> --sql_username <sql_username> --sql_password <sql_password> --mongo_host <mongo_host>')
+            print('mysql_to_mongo.py --sql_server <sql_server> --sql_username <sql_username> --sql_password <sql_password> --mongo_host <mongo_host> [ --mongo_username <mongo_username> --mongo_password <mongo_password> ]')
             sys.exit()
         elif opt == '--sql_server':
             sql_server = arg
@@ -87,7 +87,7 @@ def main(argv):
 
     if not all([sql_server, sql_username, sql_password, mongo_host]):
         print('missing one of requried args')
-        print('mysql_to_mongo.py --sql_server <sql_server> --sql_username <sql_username> --sql_password <sql_password> --mongo_host <mongo_host>')
+        print('mysql_to_mongo.py --sql_server <sql_server> --sql_username <sql_username> --sql_password <sql_password> --mongo_host <mongo_host> [ --mongo_username <mongo_username> --mongo_password <mongo_password> ]')
         sys.exit()
 
     sql_port = 3306

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -177,6 +177,15 @@ def main(argv):
 #       if insert_records%5000 == 0:
 #           print('hid {}, inserted {} records'.format(hid, insert_records))
 
+# do one final bulk insert
+    try:
+        insert_result = my_collection.insert_many(doc_insert_list,ordered=False)
+    except BulkWriteError as bwe:
+        print(bwe.details)
+    print ('inserted {} records'.format(len(insert_result.inserted_ids)))
+    doc_insert_list = []
+
+
     counter_collection.delete_many({})
     counter_collection.insert_one({'_id': 'hid_counter', 'hid_counter': max_counter + 1})
 

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -140,7 +140,7 @@ def main(argv):
     insert_records = 0
     max_counter = 0
     for x in mycursor:
-        print (x)
+#        print (x)
         doc = dict(zip(columns, x))
         hid = doc['hid']
         doc['_id'] = hid

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -135,7 +135,6 @@ def main(argv):
     print('total MySQL record count: {}'.format(total_records))
 
     mycursor.execute("SELECT * FROM Handle")
-#    myresult = mycursor.fetchall()
 
     columns = ['hid', 'id', 'file_name', 'type', 'url', 'remote_md5', 'remote_sha1',
                'created_by', 'creation_date']
@@ -145,22 +144,9 @@ def main(argv):
     doc_insert_list = []
 
     for x in mycursor:
-#        print (x)
         doc = dict(zip(columns, x))
         hid = doc['hid']
         doc['_id'] = hid
-
-#        try:
-#            counter_str = hid.split('KBH_')[-1]
-#        except Exception:
-#            counter = hid
-#        try:
-#            counter = int(counter_str)
-#        except Exception:
-#            counter = 0
-#
-#        if counter > max_counter:
-#            max_counter = counter
 
         doc_insert_list.append(doc)
         
@@ -171,11 +157,6 @@ def main(argv):
                 print(bwe.details)
             print ('inserted {} records'.format(len(insert_result.inserted_ids)))
             doc_insert_list = []
-#        if insert_one(my_collection, doc):
-#            insert_records += 1
-
-#       if insert_records%5000 == 0:
-#           print('hid {}, inserted {} records'.format(hid, insert_records))
 
 # do one final bulk insert
     try:
@@ -192,7 +173,6 @@ def main(argv):
     counter_collection.delete_many({})
     counter_collection.insert_one({'_id': 'hid_counter', 'hid_counter': max_id + 1})
 
-#    print('totally inserted {} records'.format(insert_records))
     print('max id: {} '.format(max_id))
 
 

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -169,7 +169,7 @@ def main(argv):
                 insert_result = my_collection.insert_many(doc_insert_list,ordered=False)
             except BulkWriteError as bwe:
                 print(bwe.details)
-#            print (insert_result.bulk_api_result)
+            print ('inserted {} records'.format(len(insert_result.inserted_ids)
             doc_insert_list = []
 #        if insert_one(my_collection, doc):
 #            insert_records += 1

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -103,6 +103,12 @@ def main(argv):
             sql_password = arg
         elif opt == '--mongo_host':
             mongo_host = arg
+        elif opt == '--mongo_username':
+            mongo_username = arg
+        elif opt == '--mongo_password':
+            mongo_password = arg
+        elif opt == '--mongo_authmechanism':
+            mongo_authmechanism = arg
 
     if not all([sql_server, sql_username, sql_password, mongo_host]):
         print('missing one of requried args')

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -22,12 +22,12 @@ def connect_mysql(sql_server, sql_username, sql_password, sql_database):
 
 
 def connect_mongo(mongo_host, mongo_port, mongo_database, mongo_collection,
-                  mongo_user=None, mongo_pass=None, mongo_authmechanism='DEFAULT'):
+                  mongo_username=None, mongo_password=None, mongo_authmechanism='DEFAULT'):
 
-    if mongo_user:
+    if mongo_username:
         print('mongo_user supplied, configuring client for authentication using mech ' + str(mongo_authmechanism) )
         my_client = MongoClient(mongo_host, mongo_port,
-                                username=mongo_user, password=mongo_password,
+                                username=mongo_username, password=mongo_password,
                                 authSource=mongo_database,
                                 authMechanism=mongo_authmechanism)
     else:

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -139,6 +139,8 @@ def main(argv):
 
     insert_records = 0
     max_counter = 0
+    doc_insert_list = []
+
     for x in mycursor:
 #        print (x)
         doc = dict(zip(columns, x))
@@ -157,16 +159,22 @@ def main(argv):
         if counter > max_counter:
             max_counter = counter
 
-        if insert_one(my_collection, doc):
-            insert_records += 1
+        doc_insert_list.append(doc)
+        
+        if len(doc_insert_list) % 1000 == 0:
+            insert_result = my_collection.insert_many(doc_insert_list,ordered=False)
+            print (insert_result)
+            doc_insert_list = []
+#        if insert_one(my_collection, doc):
+#            insert_records += 1
 
-        if insert_records%5000 == 0:
-            print('hid {}, inserted {} records'.format(hid, insert_records))
+#       if insert_records%5000 == 0:
+#           print('hid {}, inserted {} records'.format(hid, insert_records))
 
     counter_collection.delete_many({})
     counter_collection.insert_one({'_id': 'hid_counter', 'hid_counter': max_counter + 1})
 
-    print('totally inserted {} records'.format(insert_records))
+#    print('totally inserted {} records'.format(insert_records))
     print('largest counter'.format(max_counter))
 
 

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -160,7 +160,7 @@ def main(argv):
         if insert_one(my_collection, doc):
             insert_records += 1
 
-        if insert_records/5000 == 0:
+        if insert_records%5000 == 0:
             print('inserted {} records'.format(insert_records))
 
     counter_collection.delete_many({})

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -164,12 +164,12 @@ def main(argv):
 
         doc_insert_list.append(doc)
         
-        if len(doc_insert_list) % 1000 == 0:
+        if len(doc_insert_list) % 5000 == 0:
             try:
                 insert_result = my_collection.insert_many(doc_insert_list,ordered=False)
             except BulkWriteError as bwe:
                 print(bwe.details)
-            print (insert_result)
+            print (insert_result.bulk_api_result)
             doc_insert_list = []
 #        if insert_one(my_collection, doc):
 #            insert_records += 1

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -34,8 +34,6 @@ def connect_mongo(mongo_host, mongo_port, mongo_database, mongo_collection,
         print('no mongo_user supplied, connecting without auth')
         my_client = MongoClient(mongo_host, mongo_port)
     
-    my_client = MongoClient(mongo_host, mongo_port)
-
     try:
         my_client.server_info()  # force a call to server
     except ServerSelectionTimeoutError as e:

--- a/scripts/mysql_2_mongo.py
+++ b/scripts/mysql_2_mongo.py
@@ -80,7 +80,7 @@ def main(argv):
     sql_password = ''
     mongo_host = ''
     
-    usage_string = 'mysql_to_mongo.py --sql_server <sql_server> --sql_username <sql_username> --sql_password <sql_password> --mongo_host <mongo_host> [ --mongo_username <mongo_username> --mongo_password <mongo_password> ]'
+    usage_string = 'mysql_to_mongo.py --sql_server <sql_server> --sql_username <sql_username> --sql_password <sql_password> --mongo_host <mongo_host> [ --mongo_username <mongo_username> --mongo_password <mongo_password> [ --mongo_authmechanism <mongo_authmechanism> ] ]'
 
     try:
         opts, args = getopt.getopt(argv, "h", [a + '=' for a in input_args])


### PR DESCRIPTION
Added support for mongodb authentication
Use bulk inserts with insert_many() instead of individual inserts.  (This code is no longer re-runnable against the same mongo collection, but runs very quickly.  If we need it to be re-runnable we can use the other Bulk methods in pymongo.)