### PR TITLE
PTV-1906: Add thread locks around TTLCache access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 test_local
 sdk.cfg
 lib/AbstractHandle/AbstractHandleImpl.py.bak*
+/.settings/
+/.project
+__pycache__
+/.pydevproject

--- a/deploy.cfg
+++ b/deploy.cfg
@@ -16,9 +16,6 @@ mongo-database = handle_db
 mongo-user =
 mongo-password =
 
-# start local mongod service
-start-local-mongo = 1
-
 # KBase auth roles for the account approved to assign/modify shock node ACLs (run add_read_acl).
 admin-roles = HANDLE_ADMIN, KBASE_ADMIN
 

--- a/lib/biokbase/log.py
+++ b/lib/biokbase/log.py
@@ -1,0 +1,368 @@
+"""
+NAME
+       log
+
+DESCRIPTION
+       A library for sending logging messages to syslog.
+
+METHODS
+       log(string subsystem, hashref constraints): Initializes log. You
+           should call this at the beginning of your program. Constraints are
+           optional.
+
+       log_message(int level, string message): sends log message to syslog.
+
+       *         level: (0-9) The logging level for this message is compared to
+                    the logging level that has been set in log.  If it is <=
+                    the set logging level, the message will be sent to syslog,
+                    otherwise it will be ignored.  Logging level is set to 6
+                    if control API cannot be reached and the user does
+                    not set the log level. Log level can also be entered as
+                    string (e.g. 'DEBUG')
+
+       *          message: This is the log message.
+
+       get_log_level(): Returns the current log level as an integer.
+
+       set_log_level(integer level) : Sets the log level. Only use this if you
+           wish to override the log levels that are defined by the control API.
+           Can also be entered as string (e.g. 'DEBUG')
+
+       *          level : priority
+
+       *          0 : EMERG - system is unusable
+
+       *          1 : ALERT - component must be fixed immediately
+
+       *          2 : CRIT - secondary component must be fixed immediately
+
+       *          3 : ERR - non-urgent failure
+
+       *          4 : WARNING - warning that an error will occur if no action
+                                is taken
+
+       *          5 : NOTICE - unusual but safe conditions
+
+       *          6 : INFO - normal operational messages
+
+       *          7 : DEBUG - lowest level of debug
+
+       *          8 : DEBUG2 - second level of debug
+
+       *          9 : DEBUG3 - highest level of debug
+
+       set_log_msg_check_count(integer count): used to set the number the
+           messages that log will log before querying the control API for the
+           log level (default is 100 messages).
+
+       set_log_msg_check_interval(integer seconds): used to set the interval,
+           in seconds, that will be allowed to pass before log will query the
+           control API for the log level (default is 300 seconds).
+
+       update_api_log_level() : Checks the control API for the currently set
+           log level.
+
+       use_api_log_level() : Removes the user-defined log level and tells log
+           to use the control API-defined log level.
+"""
+
+import json as _json
+import urllib.request as _urllib2
+import syslog as _syslog
+import platform as _platform
+import inspect as _inspect
+import os as _os
+import getpass as _getpass
+import warnings as _warnings
+from configparser import ConfigParser as _ConfigParser
+import time
+
+MLOG_ENV_FILE = 'MLOG_CONFIG_FILE'
+_GLOBAL = 'global'
+MLOG_LOG_LEVEL = 'mlog_log_level'
+MLOG_API_URL = 'mlog_api_url'
+MLOG_LOG_FILE = 'mlog_log_file'
+
+DEFAULT_LOG_LEVEL = 6
+#MSG_CHECK_COUNT = 100
+#MSG_CHECK_INTERVAL = 300  # 300s = 5min
+MSG_FACILITY = _syslog.LOG_LOCAL1
+EMERG_FACILITY = _syslog.LOG_LOCAL0
+
+EMERG = 0
+ALERT = 1
+CRIT = 2
+ERR = 3
+WARNING = 4
+NOTICE = 5
+INFO = 6
+DEBUG = 7
+DEBUG2 = 8
+DEBUG3 = 9
+_MLOG_TEXT_TO_LEVEL = {'EMERG': EMERG,
+                      'ALERT': ALERT,
+                      'CRIT': CRIT,
+                      'ERR': ERR,
+                      'WARNING': WARNING,
+                      'NOTICE': NOTICE,
+                      'INFO': INFO,
+                      'DEBUG': DEBUG,
+                      'DEBUG2': DEBUG2,
+                      'DEBUG3': DEBUG3,
+                      }
+_MLOG_TO_SYSLOG = [_syslog.LOG_EMERG, _syslog.LOG_ALERT, _syslog.LOG_CRIT,
+                 _syslog.LOG_ERR, _syslog.LOG_WARNING, _syslog.LOG_NOTICE,
+                 _syslog.LOG_INFO, _syslog.LOG_DEBUG, _syslog.LOG_DEBUG,
+                 _syslog.LOG_DEBUG]
+#ALLOWED_LOG_LEVELS = set(_MLOG_TEXT_TO_LEVEL.values())
+_MLOG_LEVEL_TO_TEXT = {}
+for k, v in _MLOG_TEXT_TO_LEVEL.items():
+    _MLOG_LEVEL_TO_TEXT[v] = k
+LOG_LEVEL_MIN = min(_MLOG_LEVEL_TO_TEXT.keys())
+LOG_LEVEL_MAX = max(_MLOG_LEVEL_TO_TEXT.keys())
+del k, v
+
+
+class log(object):
+    """
+    This class contains the methods necessary for sending log messages.
+    """
+
+    def __init__(self, subsystem, constraints=None, config=None, logfile=None,
+                 ip_address=False, authuser=False, module=False,
+                 method=False, call_id=False, changecallback=None):
+        if not subsystem:
+            raise ValueError("Subsystem must be supplied")
+
+        self.user = _getpass.getuser()
+        self.parentfile = _os.path.abspath(_inspect.getfile(
+            _inspect.stack()[1][0]))
+        self.ip_address = ip_address
+        self.authuser = authuser
+        self.module = module
+        self.method = method
+        self.call_id = call_id
+        noop = lambda: None
+        self._callback = changecallback or noop
+        self._subsystem = str(subsystem)
+        self._mlog_config_file = config
+        if not self._mlog_config_file:
+            self._mlog_config_file = _os.environ.get(MLOG_ENV_FILE, None)
+        if self._mlog_config_file:
+            self._mlog_config_file = str(self._mlog_config_file)
+        self._user_log_level = -1
+        self._config_log_level = -1
+        self._user_log_file = logfile
+        self._config_log_file = None
+        self._api_log_level = -1
+        self._msgs_since_config_update = 0
+        self._time_at_config_update = time.time()
+        self.msg_count = 0
+        self._recheck_api_msg = 100
+        self._recheck_api_time = 300  # 5 mins
+        self._log_constraints = {} if not constraints else constraints
+
+        self._init = True
+        self.update_config()
+        self._init = False
+
+    def _get_time_since_start(self):
+        time_diff = time.time() - self._time_at_config_update
+        return time_diff
+
+    def get_log_level(self):
+        if(self._user_log_level != -1):
+            return self._user_log_level
+        elif(self._config_log_level != -1):
+            return self._config_log_level
+        elif(self._api_log_level != -1):
+            return self._api_log_level
+        else:
+            return DEFAULT_LOG_LEVEL
+
+    def _get_config_items(self, cfg, section):
+        cfgitems = {}
+        if cfg.has_section(section):
+            for k, v in cfg.items(section):
+                cfgitems[k] = v
+        return cfgitems
+
+    def update_config(self):
+        loglevel = self.get_log_level()
+        logfile = self.get_log_file()
+
+        self._api_log_level = -1
+        self._msgs_since_config_update = 0
+        self._time_at_config_update = time.time()
+
+        # Retrieving the control API defined log level
+        api_url = None
+        if self._mlog_config_file and _os.path.isfile(self._mlog_config_file):
+            cfg = _ConfigParser()
+            cfg.read(self._mlog_config_file)
+            cfgitems = self._get_config_items(cfg, _GLOBAL)
+            cfgitems.update(self._get_config_items(cfg, self._subsystem))
+            if MLOG_LOG_LEVEL in cfgitems:
+                try:
+                    self._config_log_level = int(cfgitems[MLOG_LOG_LEVEL])
+                except:
+                    _warnings.warn(
+                        'Cannot parse log level {} from file {} to int'.format(
+                            cfgitems[MLOG_LOG_LEVEL], self._mlog_config_file)
+                        + '. Keeping current log level.')
+            if MLOG_API_URL in cfgitems:
+                api_url = cfgitems[MLOG_API_URL]
+            if MLOG_LOG_FILE in cfgitems:
+                self._config_log_file = cfgitems[MLOG_LOG_FILE]
+        elif self._mlog_config_file:
+            _warnings.warn('Cannot read config file ' + self._mlog_config_file)
+
+        if (api_url):
+            subsystem_api_url = api_url + "/" + self._subsystem
+            try:
+                data = _json.load(_urllib2.urlopen(subsystem_api_url,
+                                                   timeout=5))
+            except _urllib2.URLError as e:
+                code_ = None
+                if hasattr(e, 'code'):
+                    code_ = ' ' + str(e.code)
+                _warnings.warn(
+                    'Could not connect to mlog api server at ' +
+                    '{}:{} {}. Using default log level {}.'.format(
+                    subsystem_api_url, code_, str(e.reason),
+                    str(DEFAULT_LOG_LEVEL)))
+            else:
+                max_matching_level = -1
+                for constraint_set in data['log_levels']:
+                    level = constraint_set['level']
+                    constraints = constraint_set['constraints']
+                    if level <= max_matching_level:
+                        continue
+
+                    matches = 1
+                    for constraint in constraints:
+                        if constraint not in self._log_constraints:
+                            matches = 0
+                        elif (self._log_constraints[constraint] !=
+                              constraints[constraint]):
+                            matches = 0
+
+                    if matches == 1:
+                        max_matching_level = level
+
+                self._api_log_level = max_matching_level
+        if ((self.get_log_level() != loglevel or
+             self.get_log_file() != logfile) and not self._init):
+            self._callback()
+
+    def _resolve_log_level(self, level):
+        if(level in _MLOG_TEXT_TO_LEVEL):
+            level = _MLOG_TEXT_TO_LEVEL[level]
+        elif(level not in _MLOG_LEVEL_TO_TEXT):
+            raise ValueError('Illegal log level')
+        return level
+
+    def set_log_level(self, level):
+        self._user_log_level = self._resolve_log_level(level)
+        self._callback()
+
+    def get_log_file(self):
+        if self._user_log_file:
+            return self._user_log_file
+        if self._config_log_file:
+            return self._config_log_file
+        return None
+
+    def set_log_file(self, filename):
+        self._user_log_file = filename
+        self._callback()
+
+    def set_log_msg_check_count(self, count):
+        count = int(count)
+        if count < 0:
+            raise ValueError('Cannot check a negative number of messages')
+        self._recheck_api_msg = count
+
+    def set_log_msg_check_interval(self, interval):
+        interval = int(interval)
+        if interval < 0:
+            raise ValueError('interval must be positive')
+        self._recheck_api_time = interval
+
+    def clear_user_log_level(self):
+        self._user_log_level = -1
+        self._callback()
+
+    def _get_ident(self, level, user, parentfile, ip_address, authuser, module,
+                   method, call_id):
+        infos = [self._subsystem, _MLOG_LEVEL_TO_TEXT[level],
+                 repr(time.time()), user, parentfile, str(_os.getpid())]
+        if self.ip_address:
+            infos.append(str(ip_address) if ip_address else '-')
+        if self.authuser:
+            infos.append(str(authuser) if authuser else '-')
+        if self.module:
+            infos.append(str(module) if module else '-')
+        if self.method:
+            infos.append(str(method) if method else '-')
+        if self.call_id:
+            infos.append(str(call_id) if call_id else '-')
+        return "[" + "] [".join(infos) + "]"
+
+    def _syslog(self, facility, level, ident, message):
+        _syslog.openlog(ident, facility)
+        if isinstance(message, str):
+            _syslog.syslog(_MLOG_TO_SYSLOG[level], message)
+        else:
+            try:
+                for m in message:
+                    _syslog.syslog(_MLOG_TO_SYSLOG[level], m)
+            except TypeError:
+                _syslog.syslog(_MLOG_TO_SYSLOG[level], str(message))
+        _syslog.closelog()
+
+    def _log(self, ident, message):
+        ident = ' '.join([str(time.strftime(
+            "%Y-%m-%d %H:%M:%S", time.localtime())),
+                        _platform.node(), ident + ': '])
+        try:
+            with open(self.get_log_file(), 'a') as log:
+                if isinstance(message, str):
+                    log.write(ident + message + '\n')
+                else:
+                    try:
+                        for m in message:
+                            log.write(ident + m + '\n')
+                    except TypeError:
+                        log.write(ident + str(message) + '\n')
+        except Exception as e:
+            err = 'Could not write to log file ' + str(self.get_log_file()) + \
+                ': ' + str(e) + '.'
+            _warnings.warn(err)
+
+    def log_message(self, level, message, ip_address=None, authuser=None,
+                    module=None, method=None, call_id=None):
+#        message = str(message)
+        level = self._resolve_log_level(level)
+
+        self.msg_count += 1
+        self._msgs_since_config_update += 1
+
+        if(self._msgs_since_config_update >= self._recheck_api_msg
+           or self._get_time_since_start() >= self._recheck_api_time):
+            self.update_config()
+
+        ident = self._get_ident(level, self.user, self.parentfile, ip_address,
+                                authuser, module, method, call_id)
+        # If this message is an emergency, send a copy to the emergency
+        # facility first.
+        if(level == 0):
+            self._syslog(EMERG_FACILITY, level, ident, message)
+
+        if(level <= self.get_log_level()):
+            self._syslog(MSG_FACILITY, level, ident, message)
+            if self.get_log_file():
+                self._log(ident, message)
+
+if __name__ == '__main__':
+    pass

--- a/test/mongo_controller.py
+++ b/test/mongo_controller.py
@@ -1,0 +1,144 @@
+"""
+A controller for MongoDB useful for running tests.
+
+Production use is not recommended.
+"""
+
+# mostly copied from https://github.com/kbase/sample_service/blob/master/test/mongo_controller.py
+# may want to make this a pip package at some point
+
+from pathlib import Path
+import os
+import tempfile
+import socket
+from contextlib import closing
+import subprocess
+import time
+import shutil
+from pymongo.mongo_client import MongoClient
+import semver
+
+
+class MongoController:
+    """
+    The main MongoDB controller class.
+
+    Attributes:
+    port - the port for the MongoDB service.
+    temp_dir - the location of the MongoDB data and logs.
+    client - a pymongo client pointed at the server.
+    db_version - the version of the mongod executable.
+    index_version - the version of the indexes created by the mongod executable - 1 for < 3.4.0,
+        2 otherwise.
+    includes_system_indexes - true if system indexes will be included when listing database
+        indexes, false otherwise.
+    """
+
+    def __init__(self, mongoexe: Path, root_temp_dir: Path, use_wired_tiger: bool = False):
+        '''
+        Create and start a new MongoDB database. An unused port will be selected for the server.
+
+        :param mongoexe: The path to the MongoDB server executable (e.g. mongod) to run.
+        :param root_temp_dir: A temporary directory in which to store MongoDB data and log files.
+            The files will be stored inside a child directory that is unique per invocation.
+        :param use_wired_tiger: For MongoDB versions > 3.0, specify that the Wired Tiger storage
+            engine should be used. Setting this to true for other versions will cause an error.
+        '''
+        if not mongoexe or not os.access(mongoexe, os.X_OK):
+            raise TestException('mongod executable path {} does not exist or is not executable.'
+                                .format(mongoexe))
+        if not root_temp_dir:
+            raise ValueError('root_temp_dir is None')
+
+        # make temp dirs
+        root_temp_dir = root_temp_dir.absolute()
+        os.makedirs(root_temp_dir, exist_ok=True)
+        self.temp_dir = Path(tempfile.mkdtemp(prefix='MongoController-', dir=str(root_temp_dir)))
+        data_dir = self.temp_dir.joinpath('data')
+        os.makedirs(data_dir)
+
+        self.port = _find_free_port()
+
+        command = [str(mongoexe), '--port', str(self.port), '--dbpath', str(data_dir),
+                   '--nojournal']
+        if use_wired_tiger:
+            command.extend(['--storageEngine', 'wiredTiger'])
+
+        self._outfile = open(self.temp_dir.joinpath('mongo.log'), 'w')
+
+        self._proc = subprocess.Popen(command, stdout=self._outfile, stderr=subprocess.STDOUT)
+        time.sleep(1)  # wait for server to start up
+        self.client: MongoClient = MongoClient('localhost', self.port)
+        # check that the server is up. See
+        # https://api.mongodb.com/python/3.7.0/api/pymongo/mongo_client.html
+        #    #pymongo.mongo_client.MongoClient
+        self.client.admin.command('ismaster')
+
+        # get some info about the db
+        self.db_version = self.client.server_info()['version']
+        s = semver.VersionInfo.parse
+        self.index_version = 2 if (s(self.db_version) >= s('3.4.0')) else 1
+        self.includes_system_indexes = (s(self.db_version) < s('3.2.0') and not use_wired_tiger)
+
+    def destroy(self, delete_temp_files: bool) -> None:
+        """
+        Shut down the MongoDB server.
+
+        :param delete_temp_files: delete all the MongoDB data files and logs generated during the
+            test.
+        """
+        if self.client:
+            self.client.close()
+        if self._proc:
+            self._proc.terminate()
+        if self._outfile:
+            self._outfile.close()
+        if delete_temp_files and self.temp_dir:
+            shutil.rmtree(self.temp_dir)
+
+    def clear_database(self, db_name, drop_indexes=False):
+        '''
+        Remove all data from a database.
+
+        :param db_name: the name of the db to clear.
+        :param drop_indexes: drop all indexes if true, retain indexes (which will be empty) if
+            false.
+        '''
+        if drop_indexes:
+            self.client.drop_database(db_name)
+        else:
+            db = self.client[db_name]
+            for name in db.list_collection_names():
+                if not name.startswith('system.'):
+                    # don't drop collection since that drops indexes
+                    db.get_collection(name).delete_many({})
+
+
+def _find_free_port() -> int:
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(('', 0))
+        return s.getsockname()[1]
+
+
+class TestException(Exception):
+    """ Exception thrown when there's problems with a test fixuture. """
+
+
+def main():
+    mongoexe = os.environ.get("MONGO_EXE_PATH")
+    root_temp_dir = os.environ.get("MONGO_TEMP_DIR")
+
+    mc = MongoController(mongoexe, root_temp_dir, False)
+    print('port: ' + str(mc.port))
+    print('temp_dir: ' + str(mc.temp_dir))
+    print('db_version: ' + mc.db_version)
+    print('index_version: ' + str(mc.index_version))
+    print('includes_system_indexes: ' + str(mc.includes_system_indexes))
+    mc.client['foo']['bar'].insert_one({'foo': 'bar'})
+    mc.clear_database('foo')
+    input('press enter to shut down')
+    mc.destroy(True)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/mongo_util.py
+++ b/test/mongo_util.py
@@ -11,16 +11,13 @@ MONGO_EXE_PATH="MONGO_EXE_PATH"
 MONGO_TEMP_DIR="MONGO_TEMP_DIR"
 
 
-def get_mongo_info() -> Tuple[str, Path]:
+def get_mongo_info() -> Tuple[Path, Path]:
     """
     Returns a tuple of
     * The path to the mongo executable from the environment
-    * the path to a directory consisting of a root directory taken from the environment appended
-      with a UUID.
+    * the path to a root directory for temporary mongo data from the environment.
     """
-    td = Path(os.environ.get(MONGO_TEMP_DIR)) / str(uuid.uuid4())
-    td.mkdir()
-    return (os.environ.get(MONGO_EXE_PATH), td)
+    return (Path(os.environ.get(MONGO_EXE_PATH)), Path(os.environ.get(MONGO_TEMP_DIR)))
 
 
 def _get_default_handles():

--- a/test/mongo_util.py
+++ b/test/mongo_util.py
@@ -1,78 +1,77 @@
 import logging
-from pymongo import MongoClient
-import subprocess
+import os
+import uuid
+from pathlib import Path
+from typing import Tuple
 from datetime import datetime
+from mongo_controller import MongoController
+from AbstractHandle.Utils import MongoUtil
+
+MONGO_EXE_PATH="MONGO_EXE_PATH"
+MONGO_TEMP_DIR="MONGO_TEMP_DIR"
 
 
-class MongoHelper:
+def get_mongo_info() -> Tuple[str, Path]:
+    """
+    Returns a tuple of
+    * The path to the mongo executable from the environment
+    * the path to a directory consisting of a root directory taken from the environment appended
+      with a UUID.
+    """
+    td = Path(os.environ.get(MONGO_TEMP_DIR)) / str(uuid.uuid4())
+    td.mkdir()
+    return (os.environ.get(MONGO_EXE_PATH), td)
 
-    def _start_service(self):
-        logging.info('starting mongod service')
 
-        logging.info('running sudo service mongodb start')
-        pipe = subprocess.Popen("sudo service mongodb start", shell=True, stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
-        stdout, stderr = pipe.communicate()
-        logging.info(stdout)
+def _get_default_handles():
 
-        if stderr:
-            raise ValueError('Cannot start mongodb')
+    raw_handles = [
+        [68020, 'b753774f-0bbd-4b96-9202-89b0c70bf31c', 'interleaved.fastq', 'shock', 'http://ci.kbase.us:7044/', None, None, 'tgu2', datetime.utcnow()],
+        [68021, '4cb26117-9793-4354-98a6-926c02a7bd0e', 'SP1.fq.gz', 'shock', 'https://ci.kbase.us/services/shock-api', '2c40e80ae4fb981541fc6918035c8707', None, 'tgu2', datetime.utcnow()],
+        [68022, 'cadf4bd8-7d95-4edd-994c-b50e29c25e50', 'SP1.fq.gz', 'shock', 'https://ci.kbase.us/services/shock-api', 'e47f6adcaa33436ad0746fe9f936e359', None, 'tgu2', datetime.utcnow()],
+        [68023, 'd24188ed-83ff-4939-9dc2-84cc758738a3', 'SP1.fq.gz', 'shock', 'https://ci.kbase.us/services/shock-api', '1da5481d162ca923c3ad27722ffdd377', None, 'tgu2', datetime.utcnow()],
+        [68024, 'acd1d64b-da98-467f-b29c-baca2862dd23', 'SP1.fq.gz', 'shock', 'https://ci.kbase.us/services/shock-api', '43966480eabf5848fdc6046ba4214bee', None, 'tgu2', datetime.utcnow()],
+        [68025, 'f973cbd3-8881-4281-afef-a8419629e813', 'SP1.fq.gz', 'shock', 'https://ci.kbase.us/services/shock-api', 'c374414a78a20feb716ea71c0ecf0a58', None, 'tgu2', datetime.utcnow()],
+        [68026, 'a676f82a-adc5-478e-b85a-d8244eae965e', 'SP1.fq.gz', 'shock', 'https://ci.kbase.us/services/shock-api', '79cc52fff3c465681d162ce3caa6e672', None, 'tgu2', datetime.utcnow()],
+        [68027, 'f4113d56-9840-4811-b32d-4ae09523389a', 'SP1.fq.gz', 'shock', 'https://ci.kbase.us/services/shock-api', '15aa9c1535b0da2158f169c748ee2a11', None, 'tgu2', datetime.utcnow()],
+        [68028, 'a31db49f-447c-4fff-96d5-2981166c0b9b', 'tmp_fastq.fq.gz', 'shock', 'https://ci.kbase.us/services/shock-api', 'f78e79df067806daa1f0946ddc790b53', None, 'tgu2', datetime.utcnow()],
+        [68029, '7a2ff7c8-d87d-4c25-ad25-5f85ea794afa', 'tmp_fastq.fq.gz', 'shock', 'https://ci.kbase.us/services/shock-api', '05361e0506af15be6701b175adbb23e4', None, 'tgu2', datetime.utcnow()]]
 
-        logging.info('running mongod --version')
-        pipe = subprocess.Popen("mongod --version", shell=True, stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
-        stdout, stderr = pipe.communicate()
+    key_names = ['_id', 'hid', 'id', 'file_name', 'type', 'url', 'remote_md5', 'remote_sha1',
+                 'created_by', 'creation_date']
 
-        logging.info(stdout)
+    handles = list()
+    for handle in raw_handles:
+        handle_doc = dict()
+        handle_doc.update({key_names[0]: int(handle[0])})
+        for idx, h in enumerate(handle):
+            handle_doc.update({key_names[idx + 1]: h})
 
-    def _get_default_handles(self):
+        handles.append(handle_doc)
 
-        raw_handles = [
-            [68020, 'b753774f-0bbd-4b96-9202-89b0c70bf31c', 'interleaved.fastq', 'shock', 'http://ci.kbase.us:7044/', None, None, 'tgu2', datetime.utcnow()],
-            [68021, '4cb26117-9793-4354-98a6-926c02a7bd0e', 'SP1.fq.gz', 'shock', 'https://ci.kbase.us/services/shock-api', '2c40e80ae4fb981541fc6918035c8707', None, 'tgu2', datetime.utcnow()],
-            [68022, 'cadf4bd8-7d95-4edd-994c-b50e29c25e50', 'SP1.fq.gz', 'shock', 'https://ci.kbase.us/services/shock-api', 'e47f6adcaa33436ad0746fe9f936e359', None, 'tgu2', datetime.utcnow()],
-            [68023, 'd24188ed-83ff-4939-9dc2-84cc758738a3', 'SP1.fq.gz', 'shock', 'https://ci.kbase.us/services/shock-api', '1da5481d162ca923c3ad27722ffdd377', None, 'tgu2', datetime.utcnow()],
-            [68024, 'acd1d64b-da98-467f-b29c-baca2862dd23', 'SP1.fq.gz', 'shock', 'https://ci.kbase.us/services/shock-api', '43966480eabf5848fdc6046ba4214bee', None, 'tgu2', datetime.utcnow()],
-            [68025, 'f973cbd3-8881-4281-afef-a8419629e813', 'SP1.fq.gz', 'shock', 'https://ci.kbase.us/services/shock-api', 'c374414a78a20feb716ea71c0ecf0a58', None, 'tgu2', datetime.utcnow()],
-            [68026, 'a676f82a-adc5-478e-b85a-d8244eae965e', 'SP1.fq.gz', 'shock', 'https://ci.kbase.us/services/shock-api', '79cc52fff3c465681d162ce3caa6e672', None, 'tgu2', datetime.utcnow()],
-            [68027, 'f4113d56-9840-4811-b32d-4ae09523389a', 'SP1.fq.gz', 'shock', 'https://ci.kbase.us/services/shock-api', '15aa9c1535b0da2158f169c748ee2a11', None, 'tgu2', datetime.utcnow()],
-            [68028, 'a31db49f-447c-4fff-96d5-2981166c0b9b', 'tmp_fastq.fq.gz', 'shock', 'https://ci.kbase.us/services/shock-api', 'f78e79df067806daa1f0946ddc790b53', None, 'tgu2', datetime.utcnow()],
-            [68029, '7a2ff7c8-d87d-4c25-ad25-5f85ea794afa', 'tmp_fastq.fq.gz', 'shock', 'https://ci.kbase.us/services/shock-api', '05361e0506af15be6701b175adbb23e4', None, 'tgu2', datetime.utcnow()]]
+    return handles
 
-        key_names = ['_id', 'hid', 'id', 'file_name', 'type', 'url', 'remote_md5', 'remote_sha1',
-                     'created_by', 'creation_date']
+def create_test_db(
+    mc: MongoController,
+    db='handle_db',
+    col=MongoUtil.MONGO_COLLECTION,
+    hid_col=MongoUtil.MONGO_HID_COUNTER_COLLECTION
+):
 
-        handles = list()
-        for handle in raw_handles:
-            handle_doc = dict()
-            handle_doc.update({key_names[0]: int(handle[0])})
-            for idx, h in enumerate(handle):
-                handle_doc.update({key_names[idx + 1]: h})
+    logging.info('creating collection and dbs')
 
-            handles.append(handle_doc)
+    my_client = mc.client
+    my_db = my_client[db]
+    my_collection = my_db[col]
+    my_hid_collection = my_db[hid_col]
 
-        return handles
+    handles = _get_default_handles()
 
-    def __init__(self):
-        self._start_service()
+    my_collection.delete_many({})
+    my_hid_collection.delete_many({})
 
-    def create_test_db(self, db='handle_db', col='handle', hid_col='handle_id_counter'):
+    my_collection.insert_many(handles)
+    my_hid_collection.insert_one({'_id': 'hid_counter', 'hid_counter': 68030})
 
-        logging.info('creating collection and dbs')
+    logging.info('created db: {}'.format(my_client.list_database_names()))
 
-        my_client = MongoClient('localhost', 27017)
-        my_db = my_client[db]
-        my_collection = my_db[col]
-        my_hid_collection = my_db[hid_col]
-
-        handles = self._get_default_handles()
-
-        my_collection.delete_many({})
-        my_hid_collection.delete_many({})
-
-        my_collection.insert_many(handles)
-        my_hid_collection.insert_one({'_id': 'hid_counter', 'hid_counter': 68030})
-
-        logging.info('created db: {}'.format(my_client.list_database_names()))
-
-        return my_client


### PR DESCRIPTION
The TTLCache provided by cachetools is not threadsafe. We have seen cases in the wild where the caching code calls a method to delete a token from the cache and then gets a `KeyError` on the `del` call:

Cachetools version: 4.2.2 (out of date, but I wanted to keep the changes here minimal)
Example exception:
```
Traceback (most recent call last):
  File "/kb/module/lib/AbstractHandle/AbstractHandleServer.py", line
101, in _call_method
    result = method(ctx, *params)
  File "/kb/module/lib/AbstractHandle/AbstractHandleImpl.py", line 335,
in add_read_acl
    returnVal = self.handler.add_read_acl(hids, ctx['token'],
username=username)
  File "/kb/module/lib/AbstractHandle/Utils/Handler.py", line 232, in
add_read_acl
    if not self._is_admin_user(token):
  File "/kb/module/lib/AbstractHandle/Utils/Handler.py", line 102, in
_is_admin_user
    self.token_cache[token] = {'customroles': customroles}
  File "/miniconda/lib/python3.6/site-packages/cachetools/ttl.py", line
87, in __setitem__
    self.expire(time)
  File "/miniconda/lib/python3.6/site-packages/cachetools/ttl.py", line
167, in expire
    cache_delitem(self, curr.key)
  File "/miniconda/lib/python3.6/site-packages/cachetools/cache.py",
line 66, in __delitem__
    del self.__data[key]
KeyError: '<token removed>'
```

The assumption here is that two threads are calling the expire() method at the same time, one deletes the token, and the other has nothing to delete and fails. This is difficult to test ex-situ so the best plan is probably to put develop up in prod for some amount of time and see if the errors go away.

This PR also contains changes to the test suite and image build as the prior image wouldn't build with a package-installed mongo. The changes also make it easier to matrix test mongo in CI in the future.