### PR TITLE
DEVOPS-1955 Lazy Load Mongo Client

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,4 +20,4 @@ jobs:
           # Fail if "new" violations detected or "any", default "new"
           failIf: new
           # Additional arguments to pass to flake8, default "." (current directory)
-          args: "--max-line-length=99 --exclude=lib/installed_clients/,lib/AbstractHandle/AbstractHandleServer.py,lib/AbstractHandle/AbstractHandleClient.py --ignore=E265 ."
+          args: "--max-line-length=99 --exclude=lib/installed_clients/,lib/AbstractHandle/AbstractHandleServer.py,lib/AbstractHandle/AbstractHandleClient.py --ignore=E265,W503 ."

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,7 @@
 * Removed Mongo setup from Dockerfile and converted test to run without `kb-sdk`.
 * Fixed broken Lintly in GHA.
 * Updated Python to 3.9.19.
+* Modified MongoUtil to defer Mongo client initialization, preventing "MongoClient opened before fork" error with uwsgi prefork + threads.
 
 ## 1.0.6
 

--- a/lib/AbstractHandle/AbstractHandleImpl.py
+++ b/lib/AbstractHandle/AbstractHandleImpl.py
@@ -42,7 +42,7 @@ provides a programmatic access to a remote file store
         self.config.setdefault('mongo-authmechanism', self.MONGO_AUTHMECHANISM)
 
         logging.basicConfig(format='%(created)s %(levelname)s: %(message)s',
-                            level=logging.DEBUG)
+                            level=logging.INFO)
 
         self.handler = Handler(self.config)
         #END_CONSTRUCTOR

--- a/lib/AbstractHandle/AbstractHandleImpl.py
+++ b/lib/AbstractHandle/AbstractHandleImpl.py
@@ -42,7 +42,7 @@ provides a programmatic access to a remote file store
         self.config.setdefault('mongo-authmechanism', self.MONGO_AUTHMECHANISM)
 
         logging.basicConfig(format='%(created)s %(levelname)s: %(message)s',
-                            level=logging.INFO)
+                            level=logging.DEBUG)
 
         self.handler = Handler(self.config)
         #END_CONSTRUCTOR

--- a/lib/AbstractHandle/Utils/MongoUtil.py
+++ b/lib/AbstractHandle/Utils/MongoUtil.py
@@ -56,6 +56,7 @@ class MongoUtil:
                                                                return_document=ReturnDocument.AFTER)['hid_counter']
 
     def __init__(self, config):
+        self.config = config
         self._hid_counter_collection = None
         self._handle_collection = None
         self.mongo_host = config['mongo-host']

--- a/lib/AbstractHandle/Utils/MongoUtil.py
+++ b/lib/AbstractHandle/Utils/MongoUtil.py
@@ -28,7 +28,7 @@ class MongoUtil:
 
         if mongo_user:
             logging.info(
-                f"mongo-user found in config file, configuring client"
+                "mongo-user found in config file, configuring client"
                 + f"for authentication using mech {mongo_authmechanism}"
             )
             my_client = MongoClient(

--- a/lib/AbstractHandle/Utils/MongoUtil.py
+++ b/lib/AbstractHandle/Utils/MongoUtil.py
@@ -4,12 +4,11 @@ import traceback
 from pymongo import MongoClient, ReturnDocument
 from pymongo.errors import ServerSelectionTimeoutError
 
-
 MONGO_COLLECTION = 'handle'
 MONGO_HID_COUNTER_COLLECTION = 'handle_id_counter'
 
-class MongoUtil:
 
+class MongoUtil:
     _HID_COUNTER_ID = 'hid_counter'
 
     def _get_collection(self, mongo_host, mongo_port, mongo_database, mongo_collection,
@@ -20,7 +19,7 @@ class MongoUtil:
         """
 
         if mongo_user:
-            logging.info('mongo-user found in config file, configuring client for authentication using mech ' + str(mongo_authmechanism) )
+            logging.info('mongo-user found in config file, configuring client for authentication using mech ' + str(mongo_authmechanism))
             my_client = MongoClient(mongo_host, mongo_port,
                                     username=mongo_user, password=mongo_password,
                                     authSource=mongo_database,
@@ -35,8 +34,8 @@ class MongoUtil:
         except ServerSelectionTimeoutError as e:
             error_msg = 'Connot connect to Mongo server\n'
             error_msg += 'ERROR -- {}:\n{}'.format(
-                            e,
-                            ''.join(traceback.format_exception(None, e, e.__traceback__)))
+                e,
+                ''.join(traceback.format_exception(None, e, e.__traceback__)))
             raise ValueError(error_msg)
 
         # TODO: check potential problems. MongoDB will create the collection if it does not exist.
@@ -67,28 +66,32 @@ class MongoUtil:
         self.mongo_authmechanism = config['mongo-authmechanism']
         self.mongo_retrywrites = config.get('mongo-retrywrites') == "true"
 
-
         logging.basicConfig(format='%(created)s %(levelname)s: %(message)s',
                             level=logging.INFO)
-
 
     @property
     def handle_collection(self):
         if self._handle_collection is None:
-            self._handle_collection = self._get_collection(self.config['mongo-host'], int(self.config['mongo-port']),
-                                                           self.config['mongo-database'], MONGO_COLLECTION,
-                                                           self.config['mongo-user'], self.config['mongo-password'],
+            self._handle_collection = self._get_collection(self.config['mongo-host'],
+                                                           int(self.config['mongo-port']),
+                                                           self.config['mongo-database'],
+                                                           MONGO_COLLECTION,
+                                                           self.config['mongo-user'],
+                                                           self.config['mongo-password'],
                                                            self.config['mongo-authmechanism'],
                                                            self.config.get('mongo-retrywrites') == "true")
-            self._handle_collection.create_index('hid', unique=True) #Might need to move this out of here
+            self._handle_collection.create_index('hid', unique=True)
         return self._handle_collection
 
     @property
     def hid_counter_collection(self):
         if self._hid_counter_collection is None:
-            self._hid_counter_collection = self._get_collection(self.config['mongo-host'], int(self.config['mongo-port']),
-                                                                self.config['mongo-database'], MONGO_HID_COUNTER_COLLECTION,
-                                                                self.config['mongo-user'], self.config['mongo-password'],
+            self._hid_counter_collection = self._get_collection(self.config['mongo-host'],
+                                                                int(self.config['mongo-port']),
+                                                                self.config['mongo-database'],
+                                                                MONGO_HID_COUNTER_COLLECTION,
+                                                                self.config['mongo-user'],
+                                                                self.config['mongo-password'],
                                                                 self.config['mongo-authmechanism'],
                                                                 self.config.get('mongo-retrywrites') == "true")
         return self._hid_counter_collection
@@ -105,8 +108,8 @@ class MongoUtil:
         except Exception as e:
             error_msg = 'Connot query doc\n'
             error_msg += 'ERROR -- {}:\n{}'.format(
-                            e,
-                            ''.join(traceback.format_exception(None, e, e.__traceback__)))
+                e,
+                ''.join(traceback.format_exception(None, e, e.__traceback__)))
             raise ValueError(error_msg)
 
         return result
@@ -122,8 +125,8 @@ class MongoUtil:
         except Exception as e:
             error_msg = 'Connot insert doc\n'
             error_msg += 'ERROR -- {}:\n{}'.format(
-                            e,
-                            ''.join(traceback.format_exception(None, e, e.__traceback__)))
+                e,
+                ''.join(traceback.format_exception(None, e, e.__traceback__)))
             raise ValueError(error_msg)
 
         return True
@@ -141,8 +144,8 @@ class MongoUtil:
         except Exception as e:
             error_msg = 'Connot update doc\n'
             error_msg += 'ERROR -- {}:\n{}'.format(
-                            e,
-                            ''.join(traceback.format_exception(None, e, e.__traceback__)))
+                e,
+                ''.join(traceback.format_exception(None, e, e.__traceback__)))
             raise ValueError(error_msg)
 
         return True
@@ -159,8 +162,8 @@ class MongoUtil:
         except Exception as e:
             error_msg = 'Connot delete doc\n'
             error_msg += 'ERROR -- {}:\n{}'.format(
-                            e,
-                            ''.join(traceback.format_exception(None, e, e.__traceback__)))
+                e,
+                ''.join(traceback.format_exception(None, e, e.__traceback__)))
             raise ValueError(error_msg)
 
         return True
@@ -178,8 +181,8 @@ class MongoUtil:
         except Exception as e:
             error_msg = 'Connot delete docs\n'
             error_msg += 'ERROR -- {}:\n{}'.format(
-                            e,
-                            ''.join(traceback.format_exception(None, e, e.__traceback__)))
+                e,
+                ''.join(traceback.format_exception(None, e, e.__traceback__)))
             raise ValueError(error_msg)
         else:
             deleted_count = result.deleted_count

--- a/lib/AbstractHandle/Utils/MongoUtil.py
+++ b/lib/AbstractHandle/Utils/MongoUtil.py
@@ -28,8 +28,8 @@ class MongoUtil:
 
         if mongo_user:
             logging.info(
-                "mongo-user found in config file, configuring client for authentication using mech "
-                + str(mongo_authmechanism)
+                f"mongo-user found in config file, configuring client"
+                + f"for authentication using mech {mongo_authmechanism}"
             )
             my_client = MongoClient(
                 mongo_host,

--- a/lib/AbstractHandle/Utils/MongoUtil.py
+++ b/lib/AbstractHandle/Utils/MongoUtil.py
@@ -19,7 +19,8 @@ class MongoUtil:
         """
 
         if mongo_user:
-            logging.info('mongo-user found in config file, configuring client for authentication using mech ' + str(mongo_authmechanism))
+            logging.info('mongo-user found in config file, configuring client for authentication using mech ' +
+                         str(mongo_authmechanism))
             my_client = MongoClient(mongo_host, mongo_port,
                                     username=mongo_user, password=mongo_password,
                                     authSource=mongo_database,

--- a/lib/AbstractHandle/Utils/MongoUtil.py
+++ b/lib/AbstractHandle/Utils/MongoUtil.py
@@ -4,39 +4,55 @@ import traceback
 from pymongo import MongoClient, ReturnDocument
 from pymongo.errors import ServerSelectionTimeoutError
 
-MONGO_COLLECTION = 'handle'
-MONGO_HID_COUNTER_COLLECTION = 'handle_id_counter'
+MONGO_COLLECTION = "handle"
+MONGO_HID_COUNTER_COLLECTION = "handle_id_counter"
 
 
 class MongoUtil:
-    _HID_COUNTER_ID = 'hid_counter'
+    _HID_COUNTER_ID = "hid_counter"
 
-    def _get_collection(self, mongo_host, mongo_port, mongo_database, mongo_collection,
-                        mongo_user=None, mongo_password=None, mongo_authmechanism='DEFAULT',
-                        mongo_retrywrites=False):
+    def _get_collection(
+        self,
+        mongo_host,
+        mongo_port,
+        mongo_database,
+        mongo_collection,
+        mongo_user=None,
+        mongo_password=None,
+        mongo_authmechanism="DEFAULT",
+        mongo_retrywrites=False,
+    ):
         """
         connect Mongo server and return a collection
         """
 
         if mongo_user:
-            logging.info('mongo-user found in config file, configuring client for authentication using mech ' +
-                         str(mongo_authmechanism))
-            my_client = MongoClient(mongo_host, mongo_port,
-                                    username=mongo_user, password=mongo_password,
-                                    authSource=mongo_database,
-                                    authMechanism=mongo_authmechanism,
-                                    retryWrites=mongo_retrywrites)
+            logging.info(
+                "mongo-user found in config file, configuring client for authentication using mech "
+                + str(mongo_authmechanism)
+            )
+            my_client = MongoClient(
+                mongo_host,
+                mongo_port,
+                username=mongo_user,
+                password=mongo_password,
+                authSource=mongo_database,
+                authMechanism=mongo_authmechanism,
+                retryWrites=mongo_retrywrites,
+            )
         else:
-            logging.info('no mongo-user found in config file, connecting without auth')
-            my_client = MongoClient(mongo_host, mongo_port, retryWrites=mongo_retrywrites)
+            logging.info("no mongo-user found in config file, connecting without auth")
+            my_client = MongoClient(
+                mongo_host, mongo_port, retryWrites=mongo_retrywrites
+            )
 
         try:
             my_client.server_info()  # force a call to server
         except ServerSelectionTimeoutError as e:
-            error_msg = 'Connot connect to Mongo server\n'
-            error_msg += 'ERROR -- {}:\n{}'.format(
-                e,
-                ''.join(traceback.format_exception(None, e, e.__traceback__)))
+            error_msg = "Connot connect to Mongo server\n"
+            error_msg += "ERROR -- {}:\n{}".format(
+                e, "".join(traceback.format_exception(None, e, e.__traceback__))
+            )
             raise ValueError(error_msg)
 
         # TODO: check potential problems. MongoDB will create the collection if it does not exist.
@@ -47,70 +63,80 @@ class MongoUtil:
 
     def increase_counter(self):
 
-        query = {'_id': self._HID_COUNTER_ID}
-        update = {'$inc': {self._HID_COUNTER_ID: 1}}
+        query = {"_id": self._HID_COUNTER_ID}
+        update = {"$inc": {self._HID_COUNTER_ID: 1}}
 
-        return self.hid_counter_collection.find_one_and_update(filter=query,
-                                                               update=update,
-                                                               upsert=True,
-                                                               return_document=ReturnDocument.AFTER)['hid_counter']
+        return self.hid_counter_collection.find_one_and_update(
+            filter=query,
+            update=update,
+            upsert=True,
+            return_document=ReturnDocument.AFTER,
+        )["hid_counter"]
 
     def __init__(self, config):
         self.config = config
         self._hid_counter_collection = None
         self._handle_collection = None
-        self.mongo_host = config['mongo-host']
-        self.mongo_port = int(config['mongo-port'])
-        self.mongo_database = config['mongo-database']
-        self.mongo_user = config['mongo-user']
-        self.mongo_pass = config['mongo-password']
-        self.mongo_authmechanism = config['mongo-authmechanism']
-        self.mongo_retrywrites = config.get('mongo-retrywrites') == "true"
+        self.mongo_host = config["mongo-host"]
+        self.mongo_port = int(config["mongo-port"])
+        self.mongo_database = config["mongo-database"]
+        self.mongo_user = config["mongo-user"]
+        self.mongo_pass = config["mongo-password"]
+        self.mongo_authmechanism = config["mongo-authmechanism"]
+        self.mongo_retrywrites = config.get("mongo-retrywrites") == "true"
 
-        logging.basicConfig(format='%(created)s %(levelname)s: %(message)s',
-                            level=logging.INFO)
+        logging.basicConfig(
+            format="%(created)s %(levelname)s: %(message)s", level=logging.INFO
+        )
 
     @property
     def handle_collection(self):
         if self._handle_collection is None:
-            self._handle_collection = self._get_collection(self.config['mongo-host'],
-                                                           int(self.config['mongo-port']),
-                                                           self.config['mongo-database'],
-                                                           MONGO_COLLECTION,
-                                                           self.config['mongo-user'],
-                                                           self.config['mongo-password'],
-                                                           self.config['mongo-authmechanism'],
-                                                           self.config.get('mongo-retrywrites') == "true")
-            self._handle_collection.create_index('hid', unique=True)
+            self._handle_collection = self._get_collection(
+                self.config["mongo-host"],
+                int(self.config["mongo-port"]),
+                self.config["mongo-database"],
+                MONGO_COLLECTION,
+                self.config["mongo-user"],
+                self.config["mongo-password"],
+                self.config["mongo-authmechanism"],
+                self.config.get("mongo-retrywrites") == "true",
+            )
+            self._handle_collection.create_index("hid", unique=True)
         return self._handle_collection
 
     @property
     def hid_counter_collection(self):
         if self._hid_counter_collection is None:
-            self._hid_counter_collection = self._get_collection(self.config['mongo-host'],
-                                                                int(self.config['mongo-port']),
-                                                                self.config['mongo-database'],
-                                                                MONGO_HID_COUNTER_COLLECTION,
-                                                                self.config['mongo-user'],
-                                                                self.config['mongo-password'],
-                                                                self.config['mongo-authmechanism'],
-                                                                self.config.get('mongo-retrywrites') == "true")
+            self._hid_counter_collection = self._get_collection(
+                self.config["mongo-host"],
+                int(self.config["mongo-port"]),
+                self.config["mongo-database"],
+                MONGO_HID_COUNTER_COLLECTION,
+                self.config["mongo-user"],
+                self.config["mongo-password"],
+                self.config["mongo-authmechanism"],
+                self.config.get("mongo-retrywrites") == "true",
+            )
         return self._hid_counter_collection
 
-    def find_in(self, elements, field_name, projection={'_id': False}, batch_size=1000):
+    def find_in(self, elements, field_name, projection={"_id": False}, batch_size=1000):
         """
         return cursor that contains docs which field column is in elements
         """
-        logging.info('start querying MongoDB')
+        logging.info("start querying MongoDB")
 
         try:
-            result = self.handle_collection.find({field_name: {'$in': elements}},
-                                                 projection=projection, batch_size=batch_size)
+            result = self.handle_collection.find(
+                {field_name: {"$in": elements}},
+                projection=projection,
+                batch_size=batch_size,
+            )
         except Exception as e:
-            error_msg = 'Connot query doc\n'
-            error_msg += 'ERROR -- {}:\n{}'.format(
-                e,
-                ''.join(traceback.format_exception(None, e, e.__traceback__)))
+            error_msg = "Connot query doc\n"
+            error_msg += "ERROR -- {}:\n{}".format(
+                e, "".join(traceback.format_exception(None, e, e.__traceback__))
+            )
             raise ValueError(error_msg)
 
         return result
@@ -119,15 +145,15 @@ class MongoUtil:
         """
         insert a doc into collection
         """
-        logging.info('start inserting document')
+        logging.info("start inserting document")
 
         try:
             self.handle_collection.insert_one(doc)
         except Exception as e:
-            error_msg = 'Connot insert doc\n'
-            error_msg += 'ERROR -- {}:\n{}'.format(
-                e,
-                ''.join(traceback.format_exception(None, e, e.__traceback__)))
+            error_msg = "Connot insert doc\n"
+            error_msg += "ERROR -- {}:\n{}".format(
+                e, "".join(traceback.format_exception(None, e, e.__traceback__))
+            )
             raise ValueError(error_msg)
 
         return True
@@ -136,17 +162,17 @@ class MongoUtil:
         """
         update a doc
         """
-        logging.info('start updating document')
+        logging.info("start updating document")
 
         try:
-            update_filter = {'hid': doc.get('hid')}
-            update = {'$set': doc}
+            update_filter = {"hid": doc.get("hid")}
+            update = {"$set": doc}
             self.handle_collection.update_one(update_filter, update)
         except Exception as e:
-            error_msg = 'Connot update doc\n'
-            error_msg += 'ERROR -- {}:\n{}'.format(
-                e,
-                ''.join(traceback.format_exception(None, e, e.__traceback__)))
+            error_msg = "Connot update doc\n"
+            error_msg += "ERROR -- {}:\n{}".format(
+                e, "".join(traceback.format_exception(None, e, e.__traceback__))
+            )
             raise ValueError(error_msg)
 
         return True
@@ -155,16 +181,16 @@ class MongoUtil:
         """
         delete a doc
         """
-        logging.info('start deleting document')
+        logging.info("start deleting document")
 
         try:
-            delete_filter = {'hid': doc.get('hid')}
+            delete_filter = {"hid": doc.get("hid")}
             self.handle_collection.delete_one(delete_filter)
         except Exception as e:
-            error_msg = 'Connot delete doc\n'
-            error_msg += 'ERROR -- {}:\n{}'.format(
-                e,
-                ''.join(traceback.format_exception(None, e, e.__traceback__)))
+            error_msg = "Connot delete doc\n"
+            error_msg += "ERROR -- {}:\n{}".format(
+                e, "".join(traceback.format_exception(None, e, e.__traceback__))
+            )
             raise ValueError(error_msg)
 
         return True
@@ -173,17 +199,17 @@ class MongoUtil:
         """
         delete a docs
         """
-        logging.info('start deleting documents')
+        logging.info("start deleting documents")
 
         try:
-            hids_to_delete = list(set([doc.get('hid') for doc in docs]))
-            delete_filter = {'hid': {'$in': hids_to_delete}}
+            hids_to_delete = list(set([doc.get("hid") for doc in docs]))
+            delete_filter = {"hid": {"$in": hids_to_delete}}
             result = self.handle_collection.delete_many(delete_filter)
         except Exception as e:
-            error_msg = 'Connot delete docs\n'
-            error_msg += 'ERROR -- {}:\n{}'.format(
-                e,
-                ''.join(traceback.format_exception(None, e, e.__traceback__)))
+            error_msg = "Connot delete docs\n"
+            error_msg += "ERROR -- {}:\n{}".format(
+                e, "".join(traceback.format_exception(None, e, e.__traceback__))
+            )
             raise ValueError(error_msg)
         else:
             deleted_count = result.deleted_count

--- a/test/MongoUtil_test.py
+++ b/test/MongoUtil_test.py
@@ -70,6 +70,11 @@ class MongoUtilTest(unittest.TestCase):
             'hid_counter_collection',
         ]
         mongo_util = self.getMongoUtil()
+
+        # Access lazy init properties to trigger their initialization
+        _ = mongo_util.handle_collection
+        _ = mongo_util.hid_counter_collection
+
         self.assertTrue(set(class_attri) <= set(mongo_util.__dict__.keys()))
         self.assertEqual(mongo_util.mongo_retrywrites, False)
 

--- a/test/MongoUtil_test.py
+++ b/test/MongoUtil_test.py
@@ -66,8 +66,8 @@ class MongoUtilTest(unittest.TestCase):
     def test_init_ok(self):
         self.start_test()
         class_attri = [
-            'mongo_host', 'mongo_port', 'mongo_database', 'handle_collection', 
-            'hid_counter_collection',
+            'mongo_host', 'mongo_port', 'mongo_database', '_handle_collection',
+            '_hid_counter_collection',
         ]
         mongo_util = self.getMongoUtil()
 


### PR DESCRIPTION
```
6/21/2024 3:50:34 PM1719003034.428176 INFO: start fetching handles
6/21/2024 3:50:34 PM1719003034.428512 INFO: start querying MongoDB
6/21/2024 3:50:34 PM/usr/local/lib/python3.9/site-packages/pymongo/mongo_client.py:2347: UserWarning: MongoClient opened before fork. May not be entirely fork-safe, proceed with caution. See PyMongo's documentation for details: https://pymongo.readthedocs.io/en/stable/faq.html#is-pymongo-fork-safe
6/21/2024 3:50:34 PM  return self._read() if self._is_read else self._write()
```
After this PR, this error no longer occurs

* Updates https://github.com/kbase/handle_service2/commit/4dba659f6f33b662ebb5fbb35d9c44927cfb6770 to lazy load
* Fixes formatting errors from lintly
* Fixes tests